### PR TITLE
Added test case to check whether server returns error

### DIFF
--- a/content/tests/app.test.js
+++ b/content/tests/app.test.js
@@ -136,3 +136,17 @@ describe('GET /content/likes/post/:comment_id', () => {
     expect(res.statusCode).toBe(200)
   })
 })
+
+describe('POST /content/posts with missing required field', () => {
+  it('Should return 400 error', async () => {
+    const res = await conn.post('/content/posts').send({
+      username: 'TEST',
+      title: 'TEST',
+      tags: 'TEST',
+      description: 'TEST'
+    })
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toBeDefined()
+    expect(res.body.error).toBe('Missing required field: image')
+  })
+})


### PR DESCRIPTION
Small 5 Anthony Mardiros, This test case checks whether the server returns a 400 error when a required field (image) is missing from the request body. It also checks whether the error message is as expected.